### PR TITLE
fix: deserializing doesn't work as intended

### DIFF
--- a/models/Movie.ts
+++ b/models/Movie.ts
@@ -44,7 +44,7 @@ export class Movie {
         }
 
         try {
-            const { title, rating, description } = this.borshAccountSchema.decode(buffer)
+            const { title, rating, description } = this.borshAccountSchema.decode(buffer.slice(1))
             return new Movie(title, rating, description)
         } catch(e) {
             console.log('Deserialization error:', e)


### PR DESCRIPTION
Please correct me if I'm wrong but isn't the first byte of the buffer the initialized bool and therefore the buffer should be sliced in order to deserialize correctly?

@jamesrp13 